### PR TITLE
Bloocoo results used only once in the first minia iteration

### DIFF
--- a/gatb
+++ b/gatb
@@ -504,7 +504,7 @@ if contigs is None: # need to create contigs, or are they given?
         log("Minia assembling at k=%d min_abundance=%d" % (k, min_abundance))
         if previous_contigs is not None:
             extra_reads = [previous_contigs]*(min_abundance+1)
-        else:
+        elif( True == use_bloocoo_preprocessing ) :
             with open( list_reads, 'r' ) as f:
                 extra_reads = f.readlines()
         create_list_reads(extra_reads)

--- a/gatb
+++ b/gatb
@@ -207,6 +207,10 @@ def create_list_reads(extra_reads = []):
                     exit("Read file %s does not exist" % filename)
                 f.write(filename + "\n")
 
+def sav_list_reads( suffix ):
+    if( os.path.exists( list_reads ) ):
+        shutil.copyfile( list_reads, ".".join( [list_reads, suffix] ) )
+            
 # ------------------------------
 # minia
 
@@ -459,7 +463,7 @@ if contigs is None: # need to create contigs, or are they given?
         list_reads_corrected = bloocoo(output_file_prefix=prefix)
 
         # now list_reads contains only the bloocoo output filename(s)
-        shutil.copyfile(list_reads,list_reads+".orig")
+        sav_list_reads( "orig" )
         shutil.copyfile(list_reads_corrected,list_reads)
         #os.rename(list_reads_corrected,list_reads)
 
@@ -500,6 +504,7 @@ if contigs is None: # need to create contigs, or are they given?
         log("Minia assembling at k=%d min_abundance=%d" % (k, min_abundance))
         extra_reads = [previous_contigs]*(min_abundance+1) if previous_contigs is not None else []
         create_list_reads(extra_reads)
+        sav_list_reads( str(k) )	# create a copy for dbg purpose
         multi_k_prefix = prefix + "_k%d" % k
         previous_contigs = minia(k, min_abundance, prefix=multi_k_prefix)
         last_k_value = k

--- a/gatb
+++ b/gatb
@@ -502,7 +502,11 @@ if contigs is None: # need to create contigs, or are they given?
     for k in sorted(dict(cutoffs).keys()):
         min_abundance = dict(cutoffs)[k]
         log("Minia assembling at k=%d min_abundance=%d" % (k, min_abundance))
-        extra_reads = [previous_contigs]*(min_abundance+1) if previous_contigs is not None else []
+        if previous_contigs is not None:
+            extra_reads = [previous_contigs]*(min_abundance+1)
+        else:
+            with open( list_reads, 'r' ) as f:
+                extra_reads = f.readlines()
         create_list_reads(extra_reads)
         sav_list_reads( str(k) )	# create a copy for dbg purpose
         multi_k_prefix = prefix + "_k%d" % k


### PR DESCRIPTION
I added a function to save list_reads file, and used it on each iteration of minia.
I placed the bloocoo results (as list_reads) in extra_reads on the first iteration.
I added a test on blooco in minia iteration to prevent entry duplication when bloocoo is not used.

=> I'll proposed another pull request to have bloocoo on all iteration of minia.
choose the one needed.